### PR TITLE
fix: Publishing phase should run after git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ If there is indeed something to release, it performs the following steps:
 2. Run user-defined verification commands (see configuration file)
 3. Update changelog file (can be disabled)
 4. Run user-defined preparation commands (see configuration file)
-5. Commit user-defined files (and the changelog if generated)
-6. Create new git tag
-7. Run user-defined publication commands (see configuration file)
-8. Push git commits (if any), and the new tag
-9. Create a github release (only if configured)
+5. Update git repository (commit user-defined files, tag and push)
+6. Run user-defined publication commands (see configuration file)
+7. Create a github release (only if configured)
 
 Any failure in one of these steps will abort the release process.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,15 +15,11 @@ use clap::{crate_authors, crate_version, AppSettings, Clap};
 ///
 /// 4. Run user-defined preparation commands (see configuration file)
 ///
-/// 5. Commit user-defined files (and the changelog if generated)
+/// 5. Update git repository (commit user-defined files, tag and push)
 ///
-/// 6. Create new git tag
+/// 6. Run user-defined publication commands (see configuration file)
 ///
-/// 7. Run user-defined publication commands (see configuration file)
-///
-/// 8. Push git commits (if any), and the new tag
-///
-/// 9. Create a github release (only if configured)
+/// 7. Create a github release (only if configured)
 ///
 ///
 /// Any failure in one of these steps will abort the release process.

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,35 +86,18 @@ fn perform_release(
         cmd::execute_all(&config.hooks.prepare, &version_str, dry_run)?;
     }
 
-    if !config.commit.files.is_empty() {
-        println!("\nCommitting files{}", title_suffix);
-        git::commit(&release.repo, &config.commit, &version_str, dry_run)?;
-    }
-
-    if !git::is_clean(&release.repo)? {
-        eprintln!("\nGit repository is dirty!");
-        process::exit(1);
-    } else {
-        println!("\nGit repository is clean");
-    }
-
-    println!("\nCreate git tag{}", title_suffix);
-    if !dry_run {
-        git::tag(
-            &release.repo,
-            &format!("{}{}", config.tag_prefix, version_str),
-            &format!("Release version {}", version_str),
-        )?;
-    }
+    println!("\nUpdating git repository{}", title_suffix);
+    git::commit(
+        &release.repo,
+        &config.commit,
+        &config.tag_prefix,
+        &version_str,
+        dry_run,
+    )?;
 
     if !config.hooks.publish.is_empty() {
         println!("\nPublishing{}", title_suffix);
         cmd::execute_all(&config.hooks.publish, &version_str, dry_run)?;
-    }
-
-    println!("\nGit push{}", title_suffix);
-    if !dry_run {
-        git::push(&release.repo)?;
     }
 
     if let Some(gh_config) = &config.github {


### PR DESCRIPTION
Fix #30

Before this change the `publish` phase was run *before* the `git push`. This can be problematic because if the `git push` fails then the software has been published, but the repository hasn't been updated.

This PR fixes it by establishing or more healthy order of the tasks. First update the git repository (commit, tag AND push). And only after succesful push: publish.

That way we publish only if the update of the git repository was successful.

One may ask what if the publish step fail? Well, given the `verify` phase was successful, we can consider the tagged commit has being publishable. If the publication fails, it means there was some unfortunate network issues (or similar), but nothing blocking. We expect the user to be able to manually checkout the tag and manually finish the publication process.