### PR TITLE
fix: Include all breaking change footers in changelog

### DIFF
--- a/changelog/src/changelog.rs
+++ b/changelog/src/changelog.rs
@@ -26,12 +26,16 @@ impl AddAssign<Change<'_>> for ChangeLog {
                 scope.clone(),
                 change.description,
             ),
-            BreakingInfo::BreakingWithDescription(info) => Self::append(
-                &mut self.scopes,
-                &mut self.breaking_changes,
-                scope.clone(),
-                info,
-            ),
+            BreakingInfo::BreakingWithDescriptions(descriptions) => {
+                for desc in descriptions {
+                    Self::append(
+                        &mut self.scopes,
+                        &mut self.breaking_changes,
+                        scope.clone(),
+                        desc,
+                    );
+                }
+            }
         }
 
         let section = match change.type_ {
@@ -207,7 +211,7 @@ mod tests {
     fn breaking_changes_info_are_appended_to_breaking_changes(#[case] type_: ChangeType) {
         let description = "Hello world!";
         let mut change = Change::new(type_, description);
-        change.breaking = BreakingInfo::BreakingWithDescription("oops...");
+        change.breaking = BreakingInfo::BreakingWithDescriptions(vec!["one", "two"]);
 
         let changelog = ChangeLog::default() + change;
 
@@ -217,7 +221,7 @@ mod tests {
                 .breaking_changes
                 .get(&None)
                 .expect("Entry not added"),
-            &vec![String::from("oops...")],
+            &vec![String::from("one"), String::from("two")],
         );
     }
 }

--- a/changelog/src/conventional_commit_parser.rs
+++ b/changelog/src/conventional_commit_parser.rs
@@ -33,7 +33,15 @@ pub(crate) fn parse(commit_msg: &str) -> Option<Change> {
                     }
                 }
                 if is_breaking {
-                    result.breaking = BreakingInfo::BreakingWithDescription(footer_content);
+                    match &mut result.breaking {
+                        BreakingInfo::NotBreaking | BreakingInfo::Breaking => {
+                            result.breaking =
+                                BreakingInfo::BreakingWithDescriptions(vec![footer_content]);
+                        }
+                        BreakingInfo::BreakingWithDescriptions(infos) => {
+                            infos.push(footer_content);
+                        }
+                    }
                 }
             }
             _ => (),

--- a/changelog/src/lib.rs
+++ b/changelog/src/lib.rs
@@ -18,11 +18,11 @@ pub struct Change<'a> {
     pub body: Option<&'a str>,
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BreakingInfo<'a> {
     NotBreaking,
     Breaking,
-    BreakingWithDescription(&'a str),
+    BreakingWithDescriptions(Vec<&'a str>),
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]

--- a/changelog/tests/commit_parser_spec.rs
+++ b/changelog/tests/commit_parser_spec.rs
@@ -127,11 +127,15 @@ fn retain_body(#[case] message: &str, #[case] expected_body: Option<&str>) {
 #[case("feat!: hello", BreakingInfo::Breaking)]
 #[case(
     "feat: hello\n\nBREAKING CHANGE: Because I had to...",
-    BreakingInfo::BreakingWithDescription("Because I had to...")
+    BreakingInfo::BreakingWithDescriptions(vec!["Because I had to..."])
 )]
 #[case(
     "feat: hello\n\nwith a body\n\nBREAKING CHANGE #\nThis\n\nis\nlife...",
-    BreakingInfo::BreakingWithDescription("This\n\nis\nlife...")
+    BreakingInfo::BreakingWithDescriptions(vec!["This\n\nis\nlife..."])
+)]
+#[case(
+    "feat: hello\n\nBREAKING CHANGE: one\nBREAKING CHANGE: two",
+    BreakingInfo::BreakingWithDescriptions(vec!["one", "two"])
 )]
 fn retain_breaking_change_description(#[case] message: &str, #[case] expected: BreakingInfo) {
     let actual = Change::parse_conventional_commit(message)

--- a/changelog/tests/markdown_spec.rs
+++ b/changelog/tests/markdown_spec.rs
@@ -29,7 +29,7 @@ fn markdown_example() {
         type_: ChangeType::Feature,
         scope: None,
         description: "Breaking feature with more info",
-        breaking: BreakingInfo::BreakingWithDescription("because!"),
+        breaking: BreakingInfo::BreakingWithDescriptions(vec!["because!"]),
         body: None,
     };
 


### PR DESCRIPTION
Fix #38 